### PR TITLE
Separate Model from View and Controller

### DIFF
--- a/src/board_renderer.rs
+++ b/src/board_renderer.rs
@@ -160,11 +160,13 @@ impl BoardRenderer {
         );
     }
 
-    /// Allows the player to choose the initial alive cells through a GUI.
+    /// Allows the player to choose the initial state of cells through a graphical interface.
     ///
-    /// This function allows the player to click on cells to toggle their state
-    /// (alive or dead) before starting the game. The player can also randomize
-    /// the initial state by pressing 'R'.
+    /// This asynchronous function provides an interactive GUI for players to set the initial state of cells in the game grid. Players can click on cells to toggle their state between alive and dead. Additionally, pressing the 'R' key will randomize the initial cell states.
+    ///
+    /// # Arguments
+    ///
+    /// * `game` - A mutable reference to a `Game` instance, which holds the current state of the cells. The function will modify this instance based on player interactions.
     async fn choose_initial_state(&mut self, game: &mut Game) {
         let mut choosing = true;
         
@@ -216,8 +218,11 @@ impl BoardRenderer {
     
     /// Resets the game state and restarts the game.
     ///
-    /// This function clears the current state of the cells, effectively resetting the game board
-    /// to its initial empty state. It then prompts the user to choose a new initial state for the cells.
+    /// This asynchronous function resets the game to its initial state and allows the player to choose a new initial state for the cells. It clears the current state of the cells, reinitializes the `Game` instance with a new empty board, and then invokes the `choose_initial_state` method to let the player set up the cells again.
+    ///
+    /// # Arguments
+    ///
+    /// * `game` - A mutable reference to a `Game` instance. This reference is updated to reflect the new game state after resetting.
     pub async fn restart(&mut self, game: &mut Game) {
         *game = Game::new(self.ncols, self.nrows);
         self.choose_initial_state(game).await;
@@ -240,6 +245,10 @@ impl BoardRenderer {
     /// The game speed controls the frequency of state updates. The `speed` variable is
     /// adjusted by multiplying or dividing it by 1.5 when the Up or Down arrow keys are pressed,
     /// respectively. The update timer ensures the game state updates according to the current speed.
+    /// 
+    /// # Arguments
+    ///
+    /// * `game` - A mutable reference to a `Game` instance that represents the current state of the game.
     pub async fn run(&mut self, game: &mut Game) {
         Self::show_start_menu().await;
         self.choose_initial_state(game).await;

--- a/src/board_renderer.rs
+++ b/src/board_renderer.rs
@@ -160,6 +160,69 @@ impl BoardRenderer {
         );
     }
 
+    /// Allows the player to choose the initial alive cells through a GUI.
+    ///
+    /// This function allows the player to click on cells to toggle their state
+    /// (alive or dead) before starting the game. The player can also randomize
+    /// the initial state by pressing 'R'.
+    async fn choose_initial_state(&mut self, game: &mut Game) {
+        let mut choosing = true;
+        
+        while choosing {
+            clear_background(BLACK);
+            self.draw_grid();
+            self.draw_cells(&game.cells);
+            
+            if is_mouse_button_pressed(MouseButton::Left) {
+                let mouse_pos = mouse_position();
+                let x = (mouse_pos.0 / self.cell_size as f32) as usize;
+                let y = (mouse_pos.1 / self.cell_size as f32) as usize;
+                game.toggle_cell_state(x, y);
+            }
+            if is_key_pressed(KeyCode::R) {
+                game.randomize();
+            }
+            
+            Self::show_initial_instructions();
+            next_frame().await;
+            
+            if is_key_pressed(KeyCode::Enter) {
+                choosing = false;
+            }
+        }
+    }
+    
+    /// Checks for key presses to pause/unpause the game, adjust the speed and show the menu.
+    ///
+    /// # Arguments
+    ///
+    /// * `paused` - A mutable reference to a boolean that indicates whether the game is paused.
+    /// * `speed` - A mutable reference to a float representing the current game speed.
+    /// * `show_menu` - A mutable reference to a boolean that controls the visibility of the menu.
+    fn check_keys(&mut self, paused: &mut bool, speed: &mut f32, show_menu: &mut bool) {
+        if is_key_pressed(KeyCode::Space) {
+            *paused = !*paused;
+        }
+        if is_key_pressed(KeyCode::Up) {
+            *speed = (*speed * 1.5).min(1000.0);
+        }
+        if is_key_pressed(KeyCode::Down) {
+            *speed = (*speed / 1.5).max(0.1);
+        }
+        if is_key_pressed(KeyCode::M) {
+            *show_menu = !*show_menu;
+        }
+    }
+    
+    /// Resets the game state and restarts the game.
+    ///
+    /// This function clears the current state of the cells, effectively resetting the game board
+    /// to its initial empty state. It then prompts the user to choose a new initial state for the cells.
+    pub async fn restart(&mut self, game: &mut Game) {
+        *game = Game::new(self.ncols, self.nrows);
+        self.choose_initial_state(game).await;
+    }
+    
     /// Runs the Game of Life.
     ///
     /// This function manages the game's lifecycle, including displaying the start menu,
@@ -211,68 +274,5 @@ impl BoardRenderer {
             self.draw_cells(&game.cells);
             next_frame().await;
         }
-    }
-
-    /// Allows the player to choose the initial alive cells through a GUI.
-    ///
-    /// This function allows the player to click on cells to toggle their state
-    /// (alive or dead) before starting the game. The player can also randomize
-    /// the initial state by pressing 'R'.
-    async fn choose_initial_state(&mut self, game: &mut Game) {
-        let mut choosing = true;
-
-        while choosing {
-            clear_background(BLACK);
-            self.draw_grid();
-            self.draw_cells(&game.cells);
-
-            if is_mouse_button_pressed(MouseButton::Left) {
-                let mouse_pos = mouse_position();
-                let x = (mouse_pos.0 / self.cell_size as f32) as usize;
-                let y = (mouse_pos.1 / self.cell_size as f32) as usize;
-                game.toggle_cell_state(x, y);
-            }
-            if is_key_pressed(KeyCode::R) {
-                game.randomize();
-            }
-
-            Self::show_initial_instructions();
-            next_frame().await;
-
-            if is_key_pressed(KeyCode::Enter) {
-                choosing = false;
-            }
-        }
-    }
-
-    /// Checks for key presses to pause/unpause the game, adjust the speed and show the menu.
-    ///
-    /// # Arguments
-    ///
-    /// * `paused` - A mutable reference to a boolean that indicates whether the game is paused.
-    /// * `speed` - A mutable reference to a float representing the current game speed.
-    /// * `show_menu` - A mutable reference to a boolean that controls the visibility of the menu.
-    fn check_keys(&mut self, paused: &mut bool, speed: &mut f32, show_menu: &mut bool) {
-        if is_key_pressed(KeyCode::Space) {
-            *paused = !*paused;
-        }
-        if is_key_pressed(KeyCode::Up) {
-            *speed = (*speed * 1.5).min(1000.0);
-        }
-        if is_key_pressed(KeyCode::Down) {
-            *speed = (*speed / 1.5).max(0.1);
-        }
-        if is_key_pressed(KeyCode::M) {
-            *show_menu = !*show_menu;
-        }
-    }
-
-    /// Resets the game state and restarts the game.
-    ///
-    /// This function clears the current state of the cells, effectively resetting the game board
-    /// to its initial empty state. It then prompts the user to choose a new initial state for the cells.
-    pub async fn restart(&mut self, game: &mut Game) {
-        *game = Game::new(self.ncols, self.nrows);
-        self.choose_initial_state(game).await;
     }
 }

--- a/src/board_renderer.rs
+++ b/src/board_renderer.rs
@@ -1,10 +1,13 @@
+use crate::game::Game;
 use macroquad::{prelude::*, ui::root_ui};
+
+const DEFAULT_SPEED: f32 = 10.0;
 
 /// Responsible for rendering the game board and handling UI elements.
 pub struct BoardRenderer {
-    pub(crate) ncols: usize,
-    pub(crate) nrows: usize,
-    pub(crate) cell_size: usize,
+    pub ncols: usize,
+    pub nrows: usize,
+    pub cell_size: usize,
 }
 
 impl BoardRenderer {
@@ -13,7 +16,7 @@ impl BoardRenderer {
     /// This function renders the start menu on the screen with instructions for opening and closing the menu,
     /// pausing the game and changing the game speed. It continuously displays
     /// the menu until the player presses the Enter key to start the game.
-    pub async fn show_start_menu() {
+    async fn show_start_menu() {
         let mut show_menu = true;
 
         while show_menu {
@@ -155,5 +158,121 @@ impl BoardRenderer {
                 ui.label(None, "Press 'M' to close the menu");
             },
         );
+    }
+
+    /// Runs the Game of Life.
+    ///
+    /// This function manages the game's lifecycle, including displaying the start menu,
+    /// allowing the player to choose the initial state of the cells, and continuously updating
+    /// and rendering the game state. The game can be paused or unpaused by pressing the Space
+    /// key, and the game speed can be adjusted using the Up and Down arrow keys.
+    ///
+    /// The `run` function performs the following actions in its main loop:
+    /// - Checks for key presses to pause/unpause the game, adjust the game speed or show the menu.
+    /// - Updates the game state if the game is not paused.
+    /// - Draws the game grid and cells.
+    /// - Displays the menu when requested and handles restarting the game if necessary.
+    /// - Waits for the next frame to be drawn, allowing for smooth animation.
+    ///
+    /// The game speed controls the frequency of state updates. The `speed` variable is
+    /// adjusted by multiplying or dividing it by 1.5 when the Up or Down arrow keys are pressed,
+    /// respectively. The update timer ensures the game state updates according to the current speed.
+    pub async fn run(&mut self, game: &mut Game) {
+        Self::show_start_menu().await;
+        self.choose_initial_state(game).await;
+
+        let mut paused = false;
+        let mut show_menu = false;
+        let mut restart = false;
+        let mut speed = DEFAULT_SPEED;
+        let mut update_timer = 0.0;
+        loop {
+            self.check_keys(&mut paused, &mut speed, &mut show_menu);
+
+            if !paused {
+                update_timer += get_frame_time();
+                if update_timer >= 1.0 / speed {
+                    game.update();
+                    update_timer = 0.0;
+                }
+            }
+            if show_menu {
+                Self::draw_menu(&mut paused, &mut restart).await;
+            }
+            if restart {
+                self.restart(game).await;
+                paused = false;
+                show_menu = false;
+                restart = false;
+            }
+
+            clear_background(BLACK);
+            self.draw_grid();
+            self.draw_cells(&game.cells);
+            next_frame().await;
+        }
+    }
+
+    /// Allows the player to choose the initial alive cells through a GUI.
+    ///
+    /// This function allows the player to click on cells to toggle their state
+    /// (alive or dead) before starting the game. The player can also randomize
+    /// the initial state by pressing 'R'.
+    async fn choose_initial_state(&mut self, game: &mut Game) {
+        let mut choosing = true;
+
+        while choosing {
+            clear_background(BLACK);
+            self.draw_grid();
+            self.draw_cells(&game.cells);
+
+            if is_mouse_button_pressed(MouseButton::Left) {
+                let mouse_pos = mouse_position();
+                let x = (mouse_pos.0 / self.cell_size as f32) as usize;
+                let y = (mouse_pos.1 / self.cell_size as f32) as usize;
+                game.toggle_cell_state(x, y);
+            }
+            if is_key_pressed(KeyCode::R) {
+                game.randomize();
+            }
+
+            Self::show_initial_instructions();
+            next_frame().await;
+
+            if is_key_pressed(KeyCode::Enter) {
+                choosing = false;
+            }
+        }
+    }
+
+    /// Checks for key presses to pause/unpause the game, adjust the speed and show the menu.
+    ///
+    /// # Arguments
+    ///
+    /// * `paused` - A mutable reference to a boolean that indicates whether the game is paused.
+    /// * `speed` - A mutable reference to a float representing the current game speed.
+    /// * `show_menu` - A mutable reference to a boolean that controls the visibility of the menu.
+    fn check_keys(&mut self, paused: &mut bool, speed: &mut f32, show_menu: &mut bool) {
+        if is_key_pressed(KeyCode::Space) {
+            *paused = !*paused;
+        }
+        if is_key_pressed(KeyCode::Up) {
+            *speed = (*speed * 1.5).min(1000.0);
+        }
+        if is_key_pressed(KeyCode::Down) {
+            *speed = (*speed / 1.5).max(0.1);
+        }
+        if is_key_pressed(KeyCode::M) {
+            *show_menu = !*show_menu;
+        }
+    }
+
+    /// Resets the game state and restarts the game.
+    ///
+    /// This function clears the current state of the cells, effectively resetting the game board
+    /// to its initial empty state. It then prompts the user to choose a new initial state for the cells.
+    pub async fn restart(&mut self, game: &mut Game) {
+        *game = Game::new(self.ncols, self.nrows);
+        self.choose_initial_state(game).await;
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,12 +1,8 @@
-use crate::board_renderer::BoardRenderer;
-use macroquad::prelude::*;
-
-const DEFAULT_SPEED: f32 = 10.0;
-
 /// Represents the state of the Game of Life.
 pub struct Game {
-    board: BoardRenderer,
-    cells: Vec<Vec<bool>>,
+    pub cells: Vec<Vec<bool>>,
+    ncols: usize,
+    nrows: usize,
 }
 
 impl Game {
@@ -14,102 +10,19 @@ impl Game {
     ///
     /// # Arguments
     ///
-    /// * `nrows` - The number of rows in the game grid.
+    /// * `board` - A `BoardRenderer` instance for rendering the game board.
     /// * `ncols` - The number of columns in the game grid.
-    /// * `cell_size` - The size of each cell in pixels.
+    /// * `nrows` - The number of rows in the game grid.
     ///
     /// # Returns
     ///
-    /// A new `Game` instance with the specified dimensions and cell size.
-    pub fn new(nrows: usize, ncols: usize, cell_size: usize) -> Self {
-        let board = BoardRenderer {
+    /// A new `Game` instance with the specified board renderer, dimensions, and with all cells initially dead.
+    pub fn new(ncols: usize, nrows: usize) -> Self {
+        let cells = vec![vec![false; nrows]; ncols];
+        Self {
+            cells,
             ncols,
             nrows,
-            cell_size,
-        };
-        let cells = vec![vec![false; nrows]; ncols];
-        Self { board, cells }
-    }
-
-    /// Runs the Game of Life.
-    ///
-    /// This function manages the game's lifecycle, including displaying the start menu,
-    /// allowing the player to choose the initial state of the cells, and continuously updating
-    /// and rendering the game state. The game can be paused or unpaused by pressing the Space
-    /// key, and the game speed can be adjusted using the Up and Down arrow keys.
-    ///
-    /// The `run` function performs the following actions in its main loop:
-    /// - Checks for key presses to pause/unpause the game, adjust the game speed or show the menu.
-    /// - Updates the game state if the game is not paused.
-    /// - Draws the game grid and cells.
-    /// - Displays the menu when requested and handles restarting the game if necessary.
-    /// - Waits for the next frame to be drawn, allowing for smooth animation.
-    ///
-    /// The game speed controls the frequency of state updates. The `speed` variable is
-    /// adjusted by multiplying or dividing it by 1.5 when the Up or Down arrow keys are pressed,
-    /// respectively. The update timer ensures the game state updates according to the current speed.
-    pub async fn run(&mut self) {
-        BoardRenderer::show_start_menu().await;
-        self.choose_initial_state().await;
-
-        let mut paused = false;
-        let mut show_menu = false;
-        let mut restart = false;
-        let mut speed = DEFAULT_SPEED;
-        let mut update_timer = 0.0;
-        loop {
-            self.check_keys(&mut paused, &mut speed, &mut show_menu);
-
-            if !paused {
-                update_timer += get_frame_time();
-                if update_timer >= 1.0 / speed {
-                    self.update();
-                    update_timer = 0.0;
-                }
-            }
-            if show_menu {
-                BoardRenderer::draw_menu(&mut paused, &mut restart).await;
-            }
-            if restart {
-                self.restart().await;
-                paused = false;
-                show_menu = false;
-                restart = false;
-            }
-
-            clear_background(BLACK);
-            self.board.draw_grid();
-            self.board.draw_cells(&self.cells);
-            next_frame().await;
-        }
-    }
-
-    /// Allows the player to choose the initial alive cells through a GUI.
-    ///
-    /// This function allows the player to click on cells to toggle their state
-    /// (alive or dead) before starting the game. The player can also randomize
-    /// the initial state by pressing 'R'.
-    async fn choose_initial_state(&mut self) {
-        let mut choosing = true;
-
-        while choosing {
-            clear_background(BLACK);
-            self.board.draw_grid();
-            self.board.draw_cells(&self.cells);
-
-            if is_mouse_button_pressed(MouseButton::Left) {
-                self.toggle_cell_state();
-            }
-            if is_key_pressed(KeyCode::R) {
-                self.randomize();
-            }
-
-            BoardRenderer::show_initial_instructions();
-            next_frame().await;
-
-            if is_key_pressed(KeyCode::Enter) {
-                choosing = false;
-            }
         }
     }
 
@@ -117,12 +30,8 @@ impl Game {
     ///
     /// This function retrieves the mouse position and toggles the state of the cell
     /// at that position from alive to dead or vice versa.
-    fn toggle_cell_state(&mut self) {
-        let mouse_pos = mouse_position();
-        let x = (mouse_pos.0 / self.board.cell_size as f32) as usize;
-        let y = (mouse_pos.1 / self.board.cell_size as f32) as usize;
-
-        if x < self.board.ncols && y < self.board.nrows {
+    pub fn toggle_cell_state(&mut self, x: usize, y: usize) {
+        if x < self.ncols && y < self.nrows {
             self.cells[x][y] = !self.cells[x][y];
         }
     }
@@ -130,44 +39,22 @@ impl Game {
     /// Randomizes the state of all cells in the grid.
     ///
     /// This function sets each cell in the grid to a random state (alive or dead).
-    fn randomize(&mut self) {
-        self.cells = (0..self.board.ncols)
-            .map(|_| (0..self.board.nrows).map(|_| ::rand::random()).collect())
+    pub fn randomize(&mut self) {
+        self.cells = (0..self.cells.len())
+            .map(|_| (0..self.cells[0].len()).map(|_| ::rand::random()).collect())
             .collect();
-    }
-
-    /// Checks for key presses to pause/unpause the game, adjust the speed and show the menu.
-    ///
-    /// # Arguments
-    ///
-    /// * `paused` - A mutable reference to a boolean that indicates whether the game is paused.
-    /// * `speed` - A mutable reference to a float representing the current game speed.
-    /// * `show_menu` - A mutable reference to a boolean that controls the visibility of the menu.
-    fn check_keys(&mut self, paused: &mut bool, speed: &mut f32, show_menu: &mut bool) {
-        if is_key_pressed(KeyCode::Space) {
-            *paused = !*paused;
-        }
-        if is_key_pressed(KeyCode::Up) {
-            *speed = (*speed * 1.5).min(1000.0);
-        }
-        if is_key_pressed(KeyCode::Down) {
-            *speed = (*speed / 1.5).max(0.1);
-        }
-        if is_key_pressed(KeyCode::M) {
-            *show_menu = !*show_menu;
-        }
     }
 
     /// Updates the game state to the next generation.
     ///
     /// This function calculates the next state of the game based on the current state
     /// and updates the cells accordingly.
-    fn update(&mut self) {
-        let mut next_cells = vec![vec![false; self.board.nrows]; self.board.ncols];
+    pub fn update(&mut self) {
+        let mut next_cells = vec![vec![false; self.nrows]; self.ncols];
 
         #[allow(clippy::needless_range_loop)] // this way is clearer than how Clippy suggests
-        for x in 0..self.board.ncols {
-            for y in 0..self.board.nrows {
+        for x in 0..self.ncols {
+            for y in 0..self.nrows {
                 let cell = self.cells[x][y];
                 let neighbors = self.count_neighbors(x as i32, y as i32);
 
@@ -191,13 +78,13 @@ impl Game {
         let mut count = 0;
         for dx in -1..=1 {
             let nx = x + dx;
-            if nx < 0 || nx >= self.board.ncols as i32 {
+            if nx < 0 || nx >= self.ncols as i32 {
                 // checks if neighbor's x is out of bounds
                 continue;
             }
             for dy in -1..=1 {
                 let ny = y + dy;
-                if ny < 0 || ny >= self.board.nrows as i32 {
+                if ny < 0 || ny >= self.nrows as i32 {
                     // checks if neighbor's y is out of bounds
                     continue;
                 }
@@ -211,15 +98,6 @@ impl Game {
         }
         count
     }
-
-    /// Resets the game state and restarts the game.
-    ///
-    /// This function clears the current state of the cells, effectively resetting the game board
-    /// to its initial empty state. It then prompts the user to choose a new initial state for the cells.
-    async fn restart(&mut self) {
-        self.cells = vec![vec![false; self.board.nrows]; self.board.ncols];
-        self.choose_initial_state().await;
-    }
 }
 
 #[cfg(test)]
@@ -228,7 +106,7 @@ mod tests {
 
     #[test]
     fn test_create_new_game() {
-        let game = Game::new(30, 40, 10);
+        let game = Game::new(40, 30);
         assert_eq!(game.cells.len(), 40);
         assert_eq!(game.cells[0].len(), 30);
     }
@@ -236,7 +114,7 @@ mod tests {
     #[rustfmt::skip]
     #[test]
     fn test_count_neighbors() {
-        let mut game = Game::new(5, 5, 1);
+        let mut game = Game::new(5, 5);
         game.cells = vec![
             vec![false, true, false, true, false],
             vec![true, true, true, false, true],
@@ -253,7 +131,7 @@ mod tests {
     #[rustfmt::skip]
     #[test]
     fn test_update() {
-        let mut game = Game::new(5, 5, 1);
+        let mut game = Game::new(5, 5);
         game.cells = vec![
             vec![false, true, false, true, false],
             vec![true, true, true, false, true],

--- a/src/game.rs
+++ b/src/game.rs
@@ -48,25 +48,6 @@ impl Game {
             .collect();
     }
 
-    /// Updates the game state to the next generation.
-    ///
-    /// This function calculates the next state of the game based on the current state
-    /// and updates the cells accordingly.
-    pub fn update(&mut self) {
-        let mut next_cells = vec![vec![false; self.nrows]; self.ncols];
-
-        #[allow(clippy::needless_range_loop)] // this way is clearer than how Clippy suggests
-        for x in 0..self.ncols {
-            for y in 0..self.nrows {
-                let cell = self.cells[x][y];
-                let neighbors = self.count_neighbors(x as i32, y as i32);
-
-                next_cells[x][y] = matches!((cell, neighbors), (true, 2) | (true, 3) | (false, 3));
-            }
-        }
-        self.cells = next_cells;
-    }
-
     /// Counts the number of alive neighbors for the given cell.
     ///
     /// # Arguments
@@ -100,6 +81,25 @@ impl Game {
             }
         }
         count
+    }
+
+    /// Updates the game state to the next generation.
+    ///
+    /// This function calculates the next state of the game based on the current state
+    /// and updates the cells accordingly.
+    pub fn update(&mut self) {
+        let mut next_cells = vec![vec![false; self.nrows]; self.ncols];
+
+        #[allow(clippy::needless_range_loop)] // this way is clearer than how Clippy suggests
+        for x in 0..self.ncols {
+            for y in 0..self.nrows {
+                let cell = self.cells[x][y];
+                let neighbors = self.count_neighbors(x as i32, y as i32);
+
+                next_cells[x][y] = matches!((cell, neighbors), (true, 2) | (true, 3) | (false, 3));
+            }
+        }
+        self.cells = next_cells;
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -6,17 +6,18 @@ pub struct Game {
 }
 
 impl Game {
-    /// Creates a new Game of Life with all cells initially dead.
+    /// Creates a new `Game` instance with all cells initially dead.
+    ///
+    /// This function initializes a new `Game` with the given dimensions and prepares a grid where all cells are dead.
     ///
     /// # Arguments
     ///
-    /// * `board` - A `BoardRenderer` instance for rendering the game board.
     /// * `ncols` - The number of columns in the game grid.
     /// * `nrows` - The number of rows in the game grid.
     ///
     /// # Returns
     ///
-    /// A new `Game` instance with the specified board renderer, dimensions, and with all cells initially dead.
+    /// A new `Game` instance with the specified dimensions, and with all cells initially set to `false` (dead).
     pub fn new(ncols: usize, nrows: usize) -> Self {
         let cells = vec![vec![false; nrows]; ncols];
         Self {
@@ -26,10 +27,12 @@ impl Game {
         }
     }
 
-    /// Toggles the state of the cell at the mouse position.
+    /// This function changes the state of the cell at the given `(x, y)` coordinates from alive to dead or vice versa.
     ///
-    /// This function retrieves the mouse position and toggles the state of the cell
-    /// at that position from alive to dead or vice versa.
+    /// # Arguments
+    ///
+    /// * `x` - The column index of the cell to be toggled. It must be within the range `[0, ncols)`.
+    /// * `y` - The row index of the cell to be toggled. It must be within the range `[0, nrows)`.
     pub fn toggle_cell_state(&mut self, x: usize, y: usize) {
         if x < self.ncols && y < self.nrows {
             self.cells[x][y] = !self.cells[x][y];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,14 @@
 //!
 //! This library provides the implementation of Conway's Game of Life, a cellular automaton devised by the mathematician John Conway.
 //! The game consists of a grid of cells that can live, die, or multiply based on specific rules.
-//! This library includes the core game logic and the rendering of the game board.
+//! This library includes the core game logic, the rendering of the game board, and the management of user interactions.
 
 /// The `game` module contains the core functionality for the Game of Life.
-/// It includes the definition of the game structure, methods for updating the game state,
-/// and handling user input.
+/// It includes the definition of the game structure and methods for updating the game state.
+/// This module represents the model part of the application.
 pub mod game;
 
-/// The `board_renderer` module is responsible for rendering the game board and UI elements.
-/// It includes methods for drawing the grid, cells, and menus, as well as displaying initial instructions.
+/// The `board_renderer` module is responsible for rendering the game board and handling user interactions.
+/// It includes methods for drawing the grid, cells, and UI elements, as well as processing user input.
+/// This module represents both the view and controller parts of the application.
 pub mod board_renderer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use conways_game_of_life::game::Game;
+use conways_game_of_life::{board_renderer::BoardRenderer, game::Game};
 use macroquad::window::*;
 use std::num::NonZeroUsize;
 
@@ -37,7 +37,7 @@ fn window_conf() -> Conf {
 /// # Usage
 ///
 /// This function uses the `#[macroquad::main(window_conf)]` attribute to set the window configuration.
-/// It then creates a new game instance and runs it asynchronously.
+/// It then creates a new game instance with a board and runs it asynchronously.
 #[macroquad::main(window_conf)]
 async fn main() {
     match (
@@ -46,8 +46,13 @@ async fn main() {
         NonZeroUsize::new(CELL_SIZE),
     ) {
         (Some(nrows), Some(ncols), Some(cell_size)) => {
-            let mut game = Game::new(nrows.get(), ncols.get(), cell_size.get());
-            game.run().await;
+            let mut board = BoardRenderer {
+                ncols: ncols.get(),
+                nrows: nrows.get(),
+                cell_size: cell_size.get(),
+            };
+            let mut game = Game::new(ncols.get(), nrows.get());
+            board.run(&mut game).await;
         }
         _ => {
             println!("Error: Invalid dimensions or cell size");


### PR DESCRIPTION
# Separate Model from View and Controller

## Overview 
This PR's work is based on [this comment](https://github.com/juanimedone/conways-game-of-life/pull/4#pullrequestreview-2226303794). It refactors the Conway's Game of Life implementation to better align with the Model-View-Controller (MVC) pattern.

## Changes

- **Separation of Concerns:**
   - **Model (game.rs):** Contains the core game logic, including state management and game updates.
   - **View and Controller (board_renderer.rs):** Manages the rendering of the game board and handles user interactions, such as toggling cell states with mouse clicks and adjusting game speed with the keyboard arrows.

- **Invert relationship:** `BoardRenderer` runs the main loop with a `Game` instance as a parameter, and interacts with it through its API. 

- **Update tests and docs.**